### PR TITLE
products にて parent_categories, categories 関連を表示/登録できるようにする

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -44,7 +44,8 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(
       :manufacturer, :name, :status, :made_to_order,
-      :started_at, :ended_at, :reserved_at, :scheduled_arrival, :url, :note
+      :started_at, :ended_at, :reserved_at, :scheduled_arrival, :url, :note,
+      category_ids: []
     )
   end
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -19,7 +19,7 @@
   <% ParentCategory.all.each_with_index do |parent, i| %>
     <p><%= parent.name %></p>
     <% parent.categories.each do |category| %>
-      <%= f.check_box :category_ids, { multiple: true, selected: @product.categories.map(&:id) }, category.id %>
+      <%= f.check_box :category_ids, { multiple: true, include_hidden: false, selected: @product.categories.map(&:id) }, category.id %>
       <%= f.label "category_ids_#{category.id}", category.name %>
     <% end %>
   <% end %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -19,7 +19,7 @@
   <% ParentCategory.all.each_with_index do |parent, i| %>
     <p><%= parent.name %></p>
     <% parent.categories.each do |category| %>
-      <%= f.check_box :category_ids, { selected: @product.categories.map(&:id) }, category.id %>
+      <%= f.check_box :category_ids, { multiple: true, selected: @product.categories.map(&:id) }, category.id %>
       <%= f.label "category_ids_#{category.id}", category.name %>
     <% end %>
   <% end %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -16,6 +16,14 @@
     <%= f.select :status, Product.statuses.keys, { selected: @product.status } %>
   </p>
 
+  <% ParentCategory.all.each_with_index do |parent, i| %>
+    <p><%= parent.name %></p>
+    <% parent.categories.each do |category| %>
+      <%= f.check_box :category_ids, { selected: @product.categories.map(&:id) }, category.id %>
+      <%= f.label "category_ids_#{category.id}", category.name %>
+    <% end %>
+  <% end %>
+
   <p>
     <%= f.label :made_to_order %>
     <%= f.check_box :made_to_order %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,6 +7,7 @@ Wish List
     <th>ID</th>
     <th>名称</th>
     <th>状態</th>
+    <th>作品名</th>
     <th>ラインナップ</th>
     <th>受注生産</th>
     <th>予約開始日時</th>
@@ -22,6 +23,7 @@ Wish List
       <td><%= product.id %></td>
       <td><%= link_to product.name, product_path(product) %></td>
       <td><%= product.status %></td>
+      <td><%= product.categories.map(&:parent).map(&:name).uniq.join(', ') %></td>
       <td>
         <ul>
           <% product.categories.each do |category| %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,6 +7,7 @@ Wish List
     <th>ID</th>
     <th>名称</th>
     <th>状態</th>
+    <th>ラインナップ</th>
     <th>受注生産</th>
     <th>予約開始日時</th>
     <th>予約終了日時</th>
@@ -21,6 +22,13 @@ Wish List
       <td><%= product.id %></td>
       <td><%= link_to product.name, product_path(product) %></td>
       <td><%= product.status %></td>
+      <td>
+        <ul>
+          <% product.categories.each do |category| %>
+            <li><%= category.name %></li>
+          <% end %>
+        </ul>
+      </td>
       <td><%= product.made_to_order %></td>
       <td><%= product.started_at %></td>
       <td><%= product.ended_at %></td>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,5 +1,7 @@
 Wish List
 
+<%= @product.categories.map(&:parent).map(&:name).uniq.join(', ') %>
+
 <table border=1>
   <tr>
     <th>ID</th>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -18,6 +18,16 @@ Wish List
     <td><%= @product.status %></td>
   </tr>
   <tr>
+    <th>名称</th>
+    <td>
+      <ul>
+        <% @product.categories.each do |category| %>
+          <li><%= category.name %></li>
+        <% end %>
+      </ul>
+    </td>
+    </tr>
+  <tr>
     <th>受注生産</th>
     <td><%= @product.made_to_order %></td>
   </tr>


### PR DESCRIPTION
## Product
### 一覧
<img width="1280" alt="スクリーンショット 2021-04-11 13 05 26" src="https://user-images.githubusercontent.com/15325910/114292027-b8d37500-9ac6-11eb-8027-4e85286c434c.png">

### 詳細
<img width="393" alt="スクリーンショット 2021-04-11 13 06 08" src="https://user-images.githubusercontent.com/15325910/114292038-c38e0a00-9ac6-11eb-85d5-786b8ae47178.png">


### フォーム
<img width="607" alt="スクリーンショット 2021-04-11 13 05 54" src="https://user-images.githubusercontent.com/15325910/114292034-c12bb000-9ac6-11eb-927b-e87bc0ef975e.png">

---
参考URL:
[form_forで複数のcheck_boxを表示して配列で取得する方法](https://qiita.com/chocoken517/items/6efb9c5a1b035f9a50fa)