### PR TITLE
ParentCategory の class_name を parent から title に変更

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
-  belongs_to :parent, class_name: 'ParentCategory', foreign_key: :parent_id
+  belongs_to :title, class_name: 'ParentCategory', foreign_key: :title_id
 
   has_many :product_categories, dependent: :destroy
   has_many :products, through: :product_categories

--- a/app/models/parent_category.rb
+++ b/app/models/parent_category.rb
@@ -1,3 +1,3 @@
 class ParentCategory < ApplicationRecord
-  has_many :categories, foreign_key: :parent_id, dependent: :destroy
+  has_many :categories, foreign_key: :title_id, dependent: :destroy
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -16,9 +16,9 @@
     <%= f.select :status, Product.statuses.keys, { selected: @product.status } %>
   </p>
 
-  <% ParentCategory.all.each_with_index do |parent, i| %>
-    <p><%= parent.name %></p>
-    <% parent.categories.each do |category| %>
+  <% ParentCategory.all.each_with_index do |title, i| %>
+    <p><%= title.name %></p>
+    <% title.categories.each do |category| %>
       <%= f.check_box :category_ids, { multiple: true, include_hidden: false, selected: @product.categories.map(&:id) }, category.id %>
       <%= f.label "category_ids_#{category.id}", category.name %>
     <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -23,7 +23,7 @@ Wish List
       <td><%= product.id %></td>
       <td><%= link_to product.name, product_path(product) %></td>
       <td><%= product.status %></td>
-      <td><%= product.categories.map(&:parent).map(&:name).uniq.join(', ') %></td>
+      <td><%= product.categories.map(&:title).map(&:name).uniq.join(', ') %></td>
       <td>
         <ul>
           <% product.categories.each do |category| %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,6 +1,6 @@
 Wish List
 
-<%= @product.categories.map(&:parent).map(&:name).uniq.join(', ') %>
+<%= @product.categories.map(&:title).map(&:name).uniq.join(', ') %>
 
 <table border=1>
   <tr>

--- a/db/migrate/20210406101929_create_categories.rb
+++ b/db/migrate/20210406101929_create_categories.rb
@@ -3,7 +3,7 @@ class CreateCategories < ActiveRecord::Migration[6.1]
     create_table :categories do |t|
       t.string :name
       t.integer :sequence
-      t.belongs_to :parent, foreign_key: { to_table: :parent_categories }
+      t.belongs_to :title, foreign_key: { to_table: :parent_categories }
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,10 +15,10 @@ ActiveRecord::Schema.define(version: 2021_04_06_111212) do
   create_table "categories", force: :cascade do |t|
     t.string "name"
     t.integer "sequence"
-    t.integer "parent_id"
+    t.integer "title_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["parent_id"], name: "index_categories_on_parent_id"
+    t.index ["title_id"], name: "index_categories_on_title_id"
   end
 
   create_table "parent_categories", force: :cascade do |t|
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 2021_04_06_111212) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  add_foreign_key "categories", "parent_categories", column: "parent_id"
+  add_foreign_key "categories", "parent_categories", column: "title_id"
   add_foreign_key "product_categories", "categories"
   add_foreign_key "product_categories", "products"
 end


### PR DESCRIPTION
カテゴリーの種類が増えるので、ふさわしい名前を再検討中。まずは `ParentCategory` モデルは「作品名」を意味する `title` という名称で取り扱うことにする。

関連 issue
https://github.com/kokoriru/merch/issues/16